### PR TITLE
Refactor model handling, support modelling with "all" models

### DIFF
--- a/eo_tides/model.py
+++ b/eo_tides/model.py
@@ -21,7 +21,7 @@ import pyproj
 import pyTMD
 from tqdm import tqdm
 
-from .utils import DatetimeLike, _set_directory, _standardise_time, idw, list_models
+from .utils import DatetimeLike, _set_directory, _standardise_models, _standardise_time, idw, list_models
 
 
 def _ensemble_model(
@@ -276,6 +276,7 @@ def _model_tides(
         )
 
         # TODO: Return constituents
+        print(model, amp.shape)
         # print(amp.shape, ph.shape, c)
         # print(pd.DataFrame({"amplitude": amp}))
 
@@ -511,7 +512,7 @@ def model_tides(
 
     """
     # Turn inputs into arrays for consistent handling
-    models_requested = list(np.atleast_1d(model))
+    # models_requested = list(np.atleast_1d(model))
     x = np.atleast_1d(x)
     y = np.atleast_1d(y)
     time = _standardise_time(time)
@@ -540,58 +541,65 @@ def model_tides(
     # provided, try global environment variable.
     directory = _set_directory(directory)
 
-    # Get full list of supported models from pyTMD database;
-    # add ensemble option to list of models
-    available_models, valid_models = list_models(
-        directory, show_available=False, show_supported=False, raise_error=True
+    # Standardise model list, handling "all" and "ensemble" functionality
+    models_to_process, models_requested, ensemble_models = _standardise_models(
+        model=model,
+        directory=directory,
+        ensemble_models=ensemble_models,
     )
-    # TODO: This is hacky, find a better way. Perhaps a kwarg that
-    # turns ensemble functionality on, and checks that supplied
-    # models match models expected for ensemble?
-    available_models = available_models + ["ensemble"]
-    valid_models = valid_models + ["ensemble"]
 
-    # Error if any models are not supported
-    if not all(m in valid_models for m in models_requested):
-        error_text = (
-            f"One or more of the requested models are not valid:\n"
-            f"{models_requested}\n\n"
-            "The following models are supported:\n"
-            f"{valid_models}"
-        )
-        raise ValueError(error_text)
+    # # Get full list of supported models from pyTMD database;
+    # # add ensemble option to list of models
+    # available_models, valid_models = list_models(
+    #     directory, show_available=False, show_supported=False, raise_error=True
+    # )
+    # # TODO: This is hacky, find a better way. Perhaps a kwarg that
+    # # turns ensemble functionality on, and checks that supplied
+    # # models match models expected for ensemble?
+    # available_models = available_models + ["ensemble"]
+    # valid_models = valid_models + ["ensemble"]
 
-    # Error if any models are not available in `directory`
-    if not all(m in available_models for m in models_requested):
-        error_text = (
-            f"One or more of the requested models are valid, but not available in `{directory}`:\n"
-            f"{models_requested}\n\n"
-            f"The following models are available in `{directory}`:\n"
-            f"{available_models}"
-        )
-        raise ValueError(error_text)
+    # # Error if any models are not supported
+    # if not all(m in valid_models for m in models_requested):
+    #     error_text = (
+    #         f"One or more of the requested models are not valid:\n"
+    #         f"{models_requested}\n\n"
+    #         "The following models are supported:\n"
+    #         f"{valid_models}"
+    #     )
+    #     raise ValueError(error_text)
 
-    # If ensemble modelling is requested, use a custom list of models
-    # for subsequent processing
-    if "ensemble" in models_requested:
-        print("Running ensemble tide modelling")
-        models_to_process = (
-            ensemble_models
-            if ensemble_models is not None
-            else [
-                "FES2014",
-                "TPXO9-atlas-v5",
-                "EOT20",
-                "HAMTIDE11",
-                "GOT4.10",
-                "FES2012",
-                "TPXO8-atlas-v1",
-            ]
-        )
+    # # Error if any models are not available in `directory`
+    # if not all(m in available_models for m in models_requested):
+    #     error_text = (
+    #         f"One or more of the requested models are valid, but not available in `{directory}`:\n"
+    #         f"{models_requested}\n\n"
+    #         f"The following models are available in `{directory}`:\n"
+    #         f"{available_models}"
+    #     )
+    #     raise ValueError(error_text)
 
-    # Otherwise, models to process are the same as those requested
-    else:
-        models_to_process = models_requested
+    # # If ensemble modelling is requested, use a custom list of models
+    # # for subsequent processing
+    # if "ensemble" in models_requested:
+    #     print("Running ensemble tide modelling")
+    #     models_to_process = (
+    #         ensemble_models
+    #         if ensemble_models is not None
+    #         else [
+    #             "FES2014",
+    #             "TPXO9-atlas-v5",
+    #             "EOT20",
+    #             "HAMTIDE11",
+    #             "GOT4.10",
+    #             "FES2012",
+    #             "TPXO8-atlas-v1",
+    #         ]
+    #     )
+
+    # # Otherwise, models to process are the same as those requested
+    # else:
+    #     models_to_process = models_requested
 
     # Update tide modelling func to add default keyword arguments that
     # are used for every iteration during parallel processing
@@ -685,7 +693,7 @@ def model_tides(
 
     # Optionally compute ensemble model and add to dataframe
     if "ensemble" in models_requested:
-        ensemble_df = _ensemble_model(tide_df, crs, models_to_process, **ensemble_kwargs)
+        ensemble_df = _ensemble_model(tide_df, crs, ensemble_models, **ensemble_kwargs)
 
         # Update requested models with any custom ensemble models, then
         # filter the dataframe to keep only models originally requested

--- a/eo_tides/model.py
+++ b/eo_tides/model.py
@@ -512,7 +512,6 @@ def model_tides(
 
     """
     # Turn inputs into arrays for consistent handling
-    # models_requested = list(np.atleast_1d(model))
     x = np.atleast_1d(x)
     y = np.atleast_1d(y)
     time = _standardise_time(time)
@@ -547,59 +546,6 @@ def model_tides(
         directory=directory,
         ensemble_models=ensemble_models,
     )
-
-    # # Get full list of supported models from pyTMD database;
-    # # add ensemble option to list of models
-    # available_models, valid_models = list_models(
-    #     directory, show_available=False, show_supported=False, raise_error=True
-    # )
-    # # TODO: This is hacky, find a better way. Perhaps a kwarg that
-    # # turns ensemble functionality on, and checks that supplied
-    # # models match models expected for ensemble?
-    # available_models = available_models + ["ensemble"]
-    # valid_models = valid_models + ["ensemble"]
-
-    # # Error if any models are not supported
-    # if not all(m in valid_models for m in models_requested):
-    #     error_text = (
-    #         f"One or more of the requested models are not valid:\n"
-    #         f"{models_requested}\n\n"
-    #         "The following models are supported:\n"
-    #         f"{valid_models}"
-    #     )
-    #     raise ValueError(error_text)
-
-    # # Error if any models are not available in `directory`
-    # if not all(m in available_models for m in models_requested):
-    #     error_text = (
-    #         f"One or more of the requested models are valid, but not available in `{directory}`:\n"
-    #         f"{models_requested}\n\n"
-    #         f"The following models are available in `{directory}`:\n"
-    #         f"{available_models}"
-    #     )
-    #     raise ValueError(error_text)
-
-    # # If ensemble modelling is requested, use a custom list of models
-    # # for subsequent processing
-    # if "ensemble" in models_requested:
-    #     print("Running ensemble tide modelling")
-    #     models_to_process = (
-    #         ensemble_models
-    #         if ensemble_models is not None
-    #         else [
-    #             "FES2014",
-    #             "TPXO9-atlas-v5",
-    #             "EOT20",
-    #             "HAMTIDE11",
-    #             "GOT4.10",
-    #             "FES2012",
-    #             "TPXO8-atlas-v1",
-    #         ]
-    #     )
-
-    # # Otherwise, models to process are the same as those requested
-    # else:
-    #     models_to_process = models_requested
 
     # Update tide modelling func to add default keyword arguments that
     # are used for every iteration during parallel processing

--- a/eo_tides/model.py
+++ b/eo_tides/model.py
@@ -276,7 +276,7 @@ def _model_tides(
         )
 
         # TODO: Return constituents
-        print(model, amp.shape)
+        # print(model, amp.shape)
         # print(amp.shape, ph.shape, c)
         # print(pd.DataFrame({"amplitude": amp}))
 

--- a/eo_tides/utils.py
+++ b/eo_tides/utils.py
@@ -68,6 +68,92 @@ def _standardise_time(
     return np.atleast_1d(time)
 
 
+def _standardise_models(
+    model: str | list[str],
+    directory: str,
+    ensemble_models: list[str] | None = None,
+) -> tuple[list, list, list]:
+    """
+    Take an input model name or list of names, and return a list
+    of models to process, requested models, and ensemble models,
+    as required by the `model_tides` function.
+
+    Handles two special values passed to `model`: "all", which
+    will model tides for all models available in `directory`, and
+    "ensemble", which will model tides for all models in a list
+    of custom ensemble models.
+    """
+
+    # Turn inputs into arrays for consistent handling
+    models_requested = list(np.atleast_1d(model))
+
+    # Get full list of supported models from pyTMD database
+    available_models, valid_models = list_models(
+        directory, show_available=False, show_supported=False, raise_error=True
+    )
+    custom_options = ["ensemble", "all"]
+
+    # Error if any models are not supported
+    if not all(m in valid_models + custom_options for m in models_requested):
+        error_text = (
+            f"One or more of the requested models are not valid:\n"
+            f"{models_requested}\n\n"
+            "The following models are supported:\n"
+            f"{valid_models}"
+        )
+        raise ValueError(error_text)
+
+    # Error if any models are not available in `directory`
+    if not all(m in available_models + custom_options for m in models_requested):
+        error_text = (
+            f"One or more of the requested models are valid, but not available in `{directory}`:\n"
+            f"{models_requested}\n\n"
+            f"The following models are available in `{directory}`:\n"
+            f"{available_models}"
+        )
+        raise ValueError(error_text)
+
+    # If "all" models are requested, update requested list to include available models
+    if "all" in models_requested:
+        models_requested = available_models + [m for m in models_requested if m != "all"]
+
+    # If "ensemble" modeling is requested, use custom list of ensemble models
+    if "ensemble" in models_requested:
+        print("Running ensemble tide modelling")
+        ensemble_models = (
+            ensemble_models
+            if ensemble_models is not None
+            else [
+                "FES2014",
+                "TPXO9-atlas-v5",
+                "EOT20",
+                "HAMTIDE11",
+                "GOT4.10",
+                "FES2012",
+                "TPXO8-atlas-v1",
+            ]
+        )
+
+        # Error if any ensemble models are not available in `directory`
+        if not all(m in available_models for m in ensemble_models):
+            error_text = (
+                f"One or more of the requested ensemble models are not available in `{directory}`:\n"
+                f"{ensemble_models}\n\n"
+                f"The following models are available in `{directory}`:\n"
+                f"{available_models}"
+            )
+            raise ValueError(error_text)
+
+        # Return set of all ensemble plus any other requested models
+        models_to_process = sorted(list(set(ensemble_models + [m for m in models_requested if m != "ensemble"])))
+
+    # Otherwise, models to process are the same as those requested
+    else:
+        models_to_process = models_requested
+
+    return models_to_process, models_requested, ensemble_models
+
+
 def _clip_model_file(
     nc: xr.Dataset,
     bbox: BoundingBox,
@@ -393,7 +479,14 @@ def list_models(
     expected_paths = {}
     for m in supported_models:
         model_file = model_database[m]["model_file"]
-        model_file = model_file[0] if isinstance(model_file, list) else model_file
+
+        # Handle GOT5.6 differently to ensure we test for presence of GOT5.6 constituents
+        if m in ("GOT5.6", "GOT5.6_extrapolated"):
+            model_file = [file for file in model_file if "GOT5.6" in file][0]
+        else:
+            model_file = model_file[0] if isinstance(model_file, list) else model_file
+
+        # Add path to dict
         expected_paths[m] = str(directory / pathlib.Path(model_file).expanduser().parent)
 
     # Define column widths

--- a/eo_tides/utils.py
+++ b/eo_tides/utils.py
@@ -70,9 +70,9 @@ def _standardise_time(
 
 def _standardise_models(
     model: str | list[str],
-    directory: str,
+    directory: str | os.PathLike,
     ensemble_models: list[str] | None = None,
-) -> tuple[list, list, list]:
+) -> tuple[list[str], list[str], list[str] | None]:
     """
     Take an input model name or list of names, and return a list
     of models to process, requested models, and ensemble models,

--- a/tests/testing.ipynb
+++ b/tests/testing.ipynb
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -354,116 +354,301 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Test `clip_models`"
+    "## `_standardise_models`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 107,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running ensemble tide modelling\n",
+      "Models to process:  ['EOT20', 'GOT5.5', 'HAMTIDE11']\n",
+      "Models requested:  ['ensemble', 'GOT5.5']\n",
+      "Ensemble models:  ['EOT20', 'HAMTIDE11']\n"
+     ]
+    },
+    {
+     "ename": "AssertionError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[107], line 167\u001b[0m\n\u001b[1;32m    164\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mEnsemble models: \u001b[39m\u001b[38;5;124m\"\u001b[39m, ensemble_models)\n\u001b[1;32m    166\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m models_to_process \u001b[38;5;241m==\u001b[39m exp_process\n\u001b[0;32m--> 167\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m models_requested \u001b[38;5;241m==\u001b[39m exp_request\n\u001b[1;32m    168\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m ensemble_models \u001b[38;5;241m==\u001b[39m exp_ensemble\n",
+      "\u001b[0;31mAssertionError\u001b[0m: "
+     ]
+    }
+   ],
    "source": [
-    "from eo_tides import clip_models"
+    "from eo_tides.utils import _set_directory, list_models\n",
+    "\n",
+    "directory = \"/home/jovyan/Robbi/eo-tides/tests/data/tide_models/\"\n",
+    "directory = _set_directory(directory)\n",
+    "\n",
+    "\n",
+    "# def _standardise_models(model, directory, ensemble_models=None):\n",
+    "\n",
+    "#     # Turn inputs into arrays for consistent handling\n",
+    "#     models_requested = list(np.atleast_1d(model))\n",
+    "\n",
+    "#     # Get full list of supported models from pyTMD database\n",
+    "#     available_models, valid_models = list_models(\n",
+    "#         directory, show_available=False, show_supported=False, raise_error=True\n",
+    "#     )\n",
+    "#     custom_options = [\"ensemble\", \"all\"]\n",
+    "\n",
+    "#     # Error if any models are not supported\n",
+    "#     if not all(m in valid_models + custom_options for m in models_requested):\n",
+    "#         error_text = (\n",
+    "#             f\"One or more of the requested models are not valid:\\n\"\n",
+    "#             f\"{models_requested}\\n\\n\"\n",
+    "#             \"The following models are supported:\\n\"\n",
+    "#             f\"{valid_models}\"\n",
+    "#         )\n",
+    "#         raise ValueError(error_text)\n",
+    "\n",
+    "#     # Error if any models are not available in `directory`\n",
+    "#     if not all(m in available_models + custom_options for m in models_requested):\n",
+    "#         error_text = (\n",
+    "#             f\"One or more of the requested models are valid, but not available in `{directory}`:\\n\"\n",
+    "#             f\"{models_requested}\\n\\n\"\n",
+    "#             f\"The following models are available in `{directory}`:\\n\"\n",
+    "#             f\"{available_models}\"\n",
+    "#         )\n",
+    "#         raise ValueError(error_text)\n",
+    "\n",
+    "#     # If \"all\" models are requested, update requested list to include available models\n",
+    "#     if \"all\" in models_requested:\n",
+    "#         models_requested = available_models + [\n",
+    "#             m for m in models_requested if m != \"all\"\n",
+    "#         ]\n",
+    "\n",
+    "#     # If \"ensemble\" modeling is requested, use custom list of ensemble models\n",
+    "#     if \"ensemble\" in models_requested:\n",
+    "#         print(\"Running ensemble tide modelling\")\n",
+    "#         ensemble_models = (\n",
+    "#             ensemble_models\n",
+    "#             if ensemble_models is not None\n",
+    "#             else [\n",
+    "#                 \"FES2014\",\n",
+    "#                 \"TPXO9-atlas-v5\",\n",
+    "#                 \"EOT20\",\n",
+    "#                 \"HAMTIDE11\",\n",
+    "#                 \"GOT4.10\",\n",
+    "#                 \"FES2012\",\n",
+    "#                 \"TPXO8-atlas-v1\",\n",
+    "#             ]\n",
+    "#         )\n",
+    "\n",
+    "#         # Error if any ensemble models are not available in `directory`\n",
+    "#         if not all(m in available_models for m in ensemble_models):\n",
+    "#             error_text = (\n",
+    "#                 f\"One or more of the requested ensemble models are not available in `{directory}`:\\n\"\n",
+    "#                 f\"{ensemble_models}\\n\\n\"\n",
+    "#                 f\"The following models are available in `{directory}`:\\n\"\n",
+    "#                 f\"{available_models}\"\n",
+    "#             )\n",
+    "#             raise ValueError(error_text)\n",
+    "\n",
+    "#         # Return set of all ensemble plus any other requested models\n",
+    "#         models_to_process = ensemble_models + [\n",
+    "#             m for m in models_requested if m != \"ensemble\"\n",
+    "#         ]\n",
+    "\n",
+    "#     # Otherwise, models to process are the same as those requested\n",
+    "#     else:\n",
+    "#         models_to_process = models_requested\n",
+    "\n",
+    "#     # Remove duplicates\n",
+    "#     models_to_process = list(set(models_to_process))\n",
+    "#     models_requested = list(set(models_requested))\n",
+    "\n",
+    "#     return models_to_process, models_requested, ensemble_models\n",
+    "\n",
+    "\n",
+    "# model = \"EOT20\"\n",
+    "# # model = [\"EOT20\", \"HAMTIDE11\"]  # = [\"EOT20\", \"FES2014\"]\n",
+    "# # model = \"all\"  # = [list all available]\n",
+    "# # model = \"ensemble\" # = [list all ensemble]\n",
+    "# # model = [\"ensemble\", \"GOT5.5\"]  # = [list all ensemble]\n",
+    "# # model = [\"all\", \"ensemble\"]\n",
+    "\n",
+    "\n",
+    "from eo_tides.utils import _standardise_models\n",
+    "\n",
+    "\n",
+    "model, ensemble_models, exp_process, exp_request, exp_ensemble = (\n",
+    "    [\"EOT20\"],\n",
+    "    None,\n",
+    "    [\"EOT20\"],\n",
+    "    [\"EOT20\"],\n",
+    "    None,\n",
+    ")\n",
+    "model, ensemble_models, exp_process, exp_request, exp_ensemble = (\n",
+    "    \"EOT20\",\n",
+    "    None,\n",
+    "    [\"EOT20\"],\n",
+    "    [\"EOT20\"],\n",
+    "    None,\n",
+    ")\n",
+    "model, ensemble_models, exp_process, exp_request, exp_ensemble = (\n",
+    "    \"all\",\n",
+    "    None,\n",
+    "    [\"GOT5.5\", \"HAMTIDE11\", \"EOT20\"],\n",
+    "    [\"GOT5.5\", \"HAMTIDE11\", \"EOT20\"],\n",
+    "    None,\n",
+    ")\n",
+    "model, ensemble_models, exp_process, exp_request, exp_ensemble = (\n",
+    "    [\"all\"],\n",
+    "    None,\n",
+    "    [\"GOT5.5\", \"HAMTIDE11\", \"EOT20\"],\n",
+    "    [\"GOT5.5\", \"HAMTIDE11\", \"EOT20\"],\n",
+    "    None,\n",
+    ")\n",
+    "model, ensemble_models, exp_process, exp_request, exp_ensemble = (\n",
+    "    \"ensemble\",\n",
+    "    [\"EOT20\", \"HAMTIDE11\"],\n",
+    "    [\"HAMTIDE11\", \"EOT20\"],\n",
+    "    [\"ensemble\"],\n",
+    "    [\"EOT20\", \"HAMTIDE11\"],\n",
+    ")\n",
+    "model, ensemble_models, exp_process, exp_request, exp_ensemble = (\n",
+    "    [\"ensemble\"],\n",
+    "    [\"EOT20\", \"HAMTIDE11\"],\n",
+    "    [\"HAMTIDE11\", \"EOT20\"],\n",
+    "    [\"ensemble\"],\n",
+    "    [\"EOT20\", \"HAMTIDE11\"],\n",
+    ")\n",
+    "model, ensemble_models, exp_process, exp_request, exp_ensemble = (\n",
+    "    [\"ensemble\", \"GOT5.5\"],\n",
+    "    [\"EOT20\", \"HAMTIDE11\"],\n",
+    "    [\"EOT20\", \"GOT5.5\", \"HAMTIDE11\"],\n",
+    "    [\"GOT5.5\", \"ensemble\"],\n",
+    "    [\"EOT20\", \"HAMTIDE11\"],\n",
+    ")\n",
+    "# model, ensemble_models, exp_process, exp_request, exp_ensemble = (\n",
+    "#     [\"all\", \"ensemble\"],\n",
+    "#     [\"EOT20\", \"HAMTIDE11\"],\n",
+    "#     [\"EOT20\", \"GOT5.5\", \"HAMTIDE11\"],\n",
+    "#     [\"GOT5.5\", \"HAMTIDE11\", \"ensemble\", \"EOT20\"],\n",
+    "#     [\"EOT20\", \"HAMTIDE11\"],\n",
+    "# )\n",
+    "\n",
+    "\n",
+    "models_to_process, models_requested, ensemble_models = _standardise_models(\n",
+    "    model=model,\n",
+    "    directory=directory,\n",
+    "    ensemble_models=ensemble_models,\n",
+    ")\n",
+    "\n",
+    "print(\"Models to process: \", models_to_process)\n",
+    "print(\"Models requested: \", models_requested)\n",
+    "print(\"Ensemble models: \", ensemble_models)\n",
+    "\n",
+    "assert models_to_process == exp_process\n",
+    "assert models_requested == exp_request\n",
+    "assert ensemble_models == exp_ensemble"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 106,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['README', 'hamtide', 'EOT20', 'GOT5']"
+       "['EOT20', 'GOT5.5', 'HAMTIDE11', 'ensemble']"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 106,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "models_requested"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['GOT5.5',\n",
+       " 'HAMTIDE11',\n",
+       " 'ensemble',\n",
+       " 'FES2012',\n",
+       " 'TPXO8-atlas-v1',\n",
+       " 'TPXO9-atlas-v5',\n",
+       " 'FES2014',\n",
+       " 'GOT4.10',\n",
+       " 'EOT20']"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "list(set(models_requested + ensemble_models))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['ensemble', 'GOT5.5']"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ensemble_models\n",
+    "\n",
+    "models_requested"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['HAMTIDE11',\n",
+       " 'GOT5.5',\n",
+       " 'FES2012',\n",
+       " 'TPXO8-atlas-v1',\n",
+       " 'TPXO9-atlas-v5',\n",
+       " 'FES2014',\n",
+       " 'GOT4.10',\n",
+       " 'EOT20']"
+      ]
+     },
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Preparing to clip suitable NetCDF models: ['EOT20', 'GOT5.5', 'HAMTIDE11']\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Clipping EOT20:   0%|          | 0/17 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Clipping EOT20: 100%|██████████| 17/17 [00:01<00:00, 14.61it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " ✅ Clipped model exported and verified\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Clipping GOT5.5: 100%|██████████| 16/16 [00:00<00:00, 29.51it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " ✅ Clipped model exported and verified\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Clipping HAMTIDE11: 100%|██████████| 9/9 [00:00<00:00, 21.21it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " ✅ Clipped model exported and verified\n",
-      "\n",
-      "Outputs exported to /tmp/tmp65uqk8w4\n",
-      "────────────────────────────────────────────────────────────────────────────────\n",
-      " 󠀠🌊  | Model                | Expected path                                       \n",
-      "────────────────────────────────────────────────────────────────────────────────\n",
-      " ✅  │ EOT20                │ /tmp/tmp65uqk8w4/EOT20/ocean_tides                  \n",
-      " ✅  │ GOT5.5               │ /tmp/tmp65uqk8w4/GOT5.5/ocean_tides                 \n",
-      " ✅  │ HAMTIDE11            │ /tmp/tmp65uqk8w4/hamtide                            \n",
-      "────────────────────────────────────────────────────────────────────────────────\n",
-      "\n",
-      "Summary:\n",
-      "Available models: 3/51\n",
-      "['GOT5', 'EOT20', 'hamtide']\n"
-     ]
-    }
-   ],
-   "source": [
-    "\n",
-    "    \n"
-   ]
   },
   {
    "cell_type": "markdown",
@@ -8436,7 +8621,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -8450,7 +8635,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Changes
- Add new "all" option to `model` param, which will model tides using all available tide models in your provided `directory`
- Move model list handling to a separate utils function `_standardise_models`, which handles providing models as strings or lists, as well as handling custom "all" and "ensemble" options

# Bug fixes
- Fix bug where GOT5.6 was not detected as a valid model because it contains files in multiple directories (both "GOT5.6" and "GOT5.5"


![image](https://github.com/user-attachments/assets/2634cb9d-4b07-4efc-a4be-b9ea1a812ac9)