### PR TITLE
Attempt to work around on-the-fly cropping issue to close #50

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -89,7 +89,6 @@ def test_clip_models():
         time=time,
         model="HAMTIDE11",
         directory=out_dir,
-        # crop=False,
     )
 
     # Verify both produce the same results
@@ -131,7 +130,6 @@ def test_clip_models_bbox(bbox, point, name):
         time=time,
         model="HAMTIDE11",
         directory=in_dir,
-        # crop=False,
     )
     df_clipped = model_tides(
         x=x,
@@ -139,7 +137,6 @@ def test_clip_models_bbox(bbox, point, name):
         time=time,
         model="HAMTIDE11",
         directory=out_dir,
-        # crop=False,
     )
 
     # Verify both produce the same results

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -72,7 +72,7 @@ def test_clip_models():
 
     # Set modelling location
     x, y = 122.28, -18.06
-    time = pd.date_range(start="2000-01", end="2001-03", freq="5h")
+    time = pd.date_range(start="2000-01", end="2001-02", freq="5h")
 
     # Model using unclipped vs clipped files
     df_unclipped = model_tides(
@@ -81,7 +81,7 @@ def test_clip_models():
         time=time,
         model="HAMTIDE11",
         directory=in_dir,
-        crop=False,
+        # crop=False,
     )
     df_clipped = model_tides(
         x=x,
@@ -89,7 +89,7 @@ def test_clip_models():
         time=time,
         model="HAMTIDE11",
         directory=out_dir,
-        crop=False,
+        # crop=False,
     )
 
     # Verify both produce the same results
@@ -98,15 +98,15 @@ def test_clip_models():
 
 # Test clipping across multiple global locations using synthetic HAMTIDE11 data
 @pytest.mark.parametrize(
-    "bbox, name",
+    "bbox, point, name",
     [
-        ((-166, 14, -151, 29), "hawaii"),  # entirely W of prime meridian
-        ((-13, 49, 6, 60), "uk"),  # crossing prime meridian
-        ((105.292969, -47.872144, 160.312500, -5.266008), "aus"),  # entirely E of prime meridian
-        ((-256.640625, 7.013668, -119.794922, 63.391522), "pacific"),  # crossing antimeridian
+        ((-166, 14, -151, 29), (19.60, -155.46), "hawaii"),  # entirely W of prime meridian
+        ((-13, 49, 6, 60), (51.47, 0.84), "uk"),  # crossing prime meridian
+        ((105, -48, 160, -5), (-25.59, 153.03), "aus"),  # entirely E of prime meridian
+        ((-257, 7, -120, 63), (19.59, -155.45), "pacific"),  # crossing antimeridian
     ],
 )
-def test_clip_models_bbox(bbox, name):
+def test_clip_models_bbox(bbox, point, name):
     # Set input and output paths
     in_dir = "tests/data/tide_models_synthetic/"
     out_dir = f"tests/data/tide_models_synthetic_{name}/"
@@ -121,8 +121,8 @@ def test_clip_models_bbox(bbox, name):
     )
 
     # Set modelling location based on bbox centroid
-    x, y = odc.geo.geom.BoundingBox(*bbox, crs="EPSG:4326").polygon.centroid.xy
-    time = pd.date_range(start="2000-01", end="2001-03", freq="5h")
+    y, x = point
+    time = pd.date_range(start="2000-01", end="2001-02", freq="5h")
 
     # Model using unclipped vs clipped files
     df_unclipped = model_tides(
@@ -131,7 +131,7 @@ def test_clip_models_bbox(bbox, name):
         time=time,
         model="HAMTIDE11",
         directory=in_dir,
-        crop=False,
+        # crop=False,
     )
     df_clipped = model_tides(
         x=x,
@@ -139,7 +139,7 @@ def test_clip_models_bbox(bbox, name):
         time=time,
         model="HAMTIDE11",
         directory=out_dir,
-        crop=False,
+        # crop=False,
     )
 
     # Verify both produce the same results

--- a/tests/testing.ipynb
+++ b/tests/testing.ipynb
@@ -175,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -235,11 +235,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1m============================= test session starts ==============================\u001b[0m\n",
+      "platform linux -- Python 3.10.15, pytest-8.3.3, pluggy-1.5.0 -- /env/bin/python3.10\n",
+      "cachedir: .pytest_cache\n",
+      "rootdir: /home/jovyan/Robbi/eo-tides\n",
+      "configfile: pyproject.toml\n",
+      "plugins: anyio-4.6.2.post1, nbval-0.11.0\n",
+      "collected 25 items / 20 deselected / 5 selected                                \u001b[0m\u001b[1m\n",
+      "\n",
+      "tests/test_utils.py::test_clip_models \u001b[32mPASSED\u001b[0m\u001b[33m                             [ 20%]\u001b[0m\n",
+      "tests/test_utils.py::test_clip_models_bbox[bbox0-point0-hawaii] \u001b[32mPASSED\u001b[0m\u001b[33m   [ 40%]\u001b[0m\n",
+      "tests/test_utils.py::test_clip_models_bbox[bbox1-point1-uk] \u001b[32mPASSED\u001b[0m\u001b[33m       [ 60%]\u001b[0m\n",
+      "tests/test_utils.py::test_clip_models_bbox[bbox2-point2-aus] \u001b[32mPASSED\u001b[0m\u001b[33m      [ 80%]\u001b[0m\n",
+      "tests/test_utils.py::test_clip_models_bbox[bbox3-point3-pacific] \u001b[32mPASSED\u001b[0m\u001b[33m  [100%]\u001b[0m\n",
+      "\n",
+      "\u001b[33m=============================== warnings summary ===============================\u001b[0m\n",
+      "<frozen importlib._bootstrap>:241\n",
+      "  <frozen importlib._bootstrap>:241: RuntimeWarning: numpy.ndarray size changed, may indicate binary incompatibility. Expected 16 from C header, got 96 from PyObject\n",
+      "\n",
+      "tests/test_utils.py: 20 warnings\n",
+      "  /env/lib/python3.10/site-packages/pyproj/transformer.py:817: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)\n",
+      "    return self._transformer._transform_point(\n",
+      "\n",
+      "tests/test_utils.py::test_clip_models_bbox[bbox0-point0-hawaii]\n",
+      "  /home/jovyan/Robbi/eo-tides/eo_tides/model.py:127: UserWarning: On-the-fly cropping is not compatible with the provided clipped model files; running with `crop=False`.\n",
+      "    warnings.warn(\"On-the-fly cropping is not compatible with the provided \"\n",
+      "\n",
+      "-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html\n",
+      "\u001b[33m================ \u001b[32m5 passed\u001b[0m, \u001b[33m\u001b[1m20 deselected\u001b[0m, \u001b[33m\u001b[1m22 warnings\u001b[0m\u001b[33m in 16.32s\u001b[0m\u001b[33m ================\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
-    "!export EO_TIDES_TIDE_MODELS=./tests/data/tide_models && pytest tests/test_utils.py --verbose -k test_clip_models_bbox"
+    "!export EO_TIDES_TIDE_MODELS=./tests/data/tide_models && pytest tests/test_utils.py --verbose -k test_clip_models"
    ]
   },
   {


### PR DESCRIPTION
Cropping on-the-fly param with `crop=True` (i.e. calling `pyTMD`'s `crop` functionality: https://github.com/pyTMD/pyTMD/pull/313) currently fails when applied to model files that have been clipped using the `clip_models` function to be entirely restricted to the western hemisphere (clipped model files that overlap the eastern hemisphere work fine).

This PR adds a workaround by updating the `crop` param to support three options:

- `crop="auto"` (new default): use `crop=True` by default. If that fails (e.g. clipped western hemisphere files), use `crop=False`
- `crop=True`: will work for most cases except clipped western hemisphere files (which will raise an error)
- `crop=False`: will work for all cases; may be a bit slower for large analyses

## Other
Also added support for `pyTMD`'s `append_node` functionality to `model_tides`.

