### PR TITLE
Reformat code with additional `ruff` linting rules

### DIFF
--- a/.github/workflows/paper.yml
+++ b/.github/workflows/paper.yml
@@ -1,19 +1,5 @@
 name: Draft paper PDF
-on:
-  push:
-    branches:
-      - main
-      - JOSS_paper
-    paths:
-      - paper/**
-      - .github/workflows/paper.yml
-  pull_request:
-    branches:
-      - main
-      - JOSS_paper
-    paths:
-      - paper/**
-      - .github/workflows/paper.yml
+on: workflow_dispatch
 
 jobs:
   paper:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,16 +10,10 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
     rev: v0.6.4
     hooks:
-      # Run the linter.
-      - id: ruff
-        types_or: [python, pyi]
-        args: [--fix, --select=I] # --select=ALL, I
-      # Run the formatter.
-      - id: ruff-format
-        types_or: [python, pyi]
+      - id: ruff # Run linter using pyproject.toml config
+      - id: ruff-format # Run formatter using pyproject.toml config
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.0.3"

--- a/docs/notebooks/Case_study_intertidal.ipynb
+++ b/docs/notebooks/Case_study_intertidal.ipynb
@@ -49,10 +49,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import odc.stac\n",
-    "import pystac_client\n",
-    "import planetary_computer\n",
     "import matplotlib.pyplot as plt\n",
+    "import odc.stac\n",
+    "import planetary_computer\n",
+    "import pystac_client\n",
     "\n",
     "from eo_tides.eo import tag_tides\n",
     "from eo_tides.stats import tide_stats\n",
@@ -264,7 +264,7 @@
    ],
    "source": [
     "# Calculate NDWI\n",
-    "ds[[\"ndwi\"]] = (ds.green - ds.nir08) / (ds.green + ds.nir08) \n",
+    "ds[[\"ndwi\"]] = (ds.green - ds.nir08) / (ds.green + ds.nir08)\n",
     "\n",
     "# Plot a single timestep\n",
     "ds.ndwi.isel(time=1).plot.imshow(vmin=-0.5, vmax=0.5, cmap=\"RdBu\")"

--- a/docs/notebooks/Model_tides.ipynb
+++ b/docs/notebooks/Model_tides.ipynb
@@ -222,8 +222,9 @@
     }
    ],
    "source": [
-    "from eo_tides.model import model_tides\n",
     "import pandas as pd\n",
+    "\n",
+    "from eo_tides.model import model_tides\n",
     "\n",
     "tide_df = model_tides(\n",
     "    x=122.2186,\n",
@@ -680,13 +681,11 @@
     }
    ],
    "source": [
-    "df = pd.DataFrame(\n",
-    "    {\n",
-    "        \"time\": pd.date_range(start=\"2018-01-01\", end=\"2018-01-31\", periods=2),\n",
-    "        \"x\": [122.21, 122.22],\n",
-    "        \"y\": [-18.20, -18.21],\n",
-    "    }\n",
-    ")\n",
+    "df = pd.DataFrame({\n",
+    "    \"time\": pd.date_range(start=\"2018-01-01\", end=\"2018-01-31\", periods=2),\n",
+    "    \"x\": [122.21, 122.22],\n",
+    "    \"y\": [-18.20, -18.21],\n",
+    "})\n",
     "df"
    ]
   },
@@ -1496,7 +1495,7 @@
     "    x=122.2186,\n",
     "    y=-18.0008,\n",
     "    time=pd.date_range(start=\"2018-01-01\", end=\"2018-01-02\", freq=\"5h\"),\n",
-    "    time_offset='30 min',\n",
+    "    time_offset=\"30 min\",\n",
     "    directory=directory,\n",
     ")"
    ]

--- a/docs/notebooks/Satellite_data.ipynb
+++ b/docs/notebooks/Satellite_data.ipynb
@@ -109,8 +109,8 @@
    ],
    "source": [
     "import odc.stac\n",
-    "import pystac_client\n",
     "import planetary_computer\n",
+    "import pystac_client\n",
     "\n",
     "# Connect to STAC catalog\n",
     "catalog = pystac_client.Client.open(\n",
@@ -1031,7 +1031,7 @@
     ")\n",
     "\n",
     "# Plot the first four timesteps in our data\n",
-    "tides_lowres.isel(time=[0, 1, 2, 3]).plot.imshow(col=\"time\", vmin=-3, vmax=3, cmap=\"RdBu\")\n"
+    "tides_lowres.isel(time=[0, 1, 2, 3]).plot.imshow(col=\"time\", vmin=-3, vmax=3, cmap=\"RdBu\")"
    ]
   },
   {
@@ -2071,14 +2071,14 @@
     "import pandas as pd\n",
     "\n",
     "custom_times = pd.date_range(\n",
-    "    start=\"2022-01-01\", \n",
-    "    end=\"2022-01-02\", \n",
+    "    start=\"2022-01-01\",\n",
+    "    end=\"2022-01-02\",\n",
     "    freq=\"6h\",\n",
     ")\n",
     "\n",
     "# Model tides spatially\n",
     "tides_highres = pixel_tides(\n",
-    "    data=ds, \n",
+    "    data=ds,\n",
     "    time=custom_times,\n",
     "    model=model,\n",
     "    directory=directory,\n",

--- a/docs/notebooks/Tide_statistics.ipynb
+++ b/docs/notebooks/Tide_statistics.ipynb
@@ -701,8 +701,8 @@
    ],
    "source": [
     "import odc.stac\n",
-    "import pystac_client\n",
     "import planetary_computer\n",
+    "import pystac_client\n",
     "\n",
     "# Connect to STAC catalog\n",
     "catalog = pystac_client.Client.open(\n",
@@ -807,7 +807,7 @@
     "    data=ds_s2,\n",
     "    model=model,\n",
     "    directory=directory,\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -1603,7 +1603,7 @@
     "    data=ds_s1,\n",
     "    model=model,\n",
     "    directory=directory,\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -2411,7 +2411,7 @@
     "    plot_var=\"satellite_name\",\n",
     "    model=model,\n",
     "    directory=directory,\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -3110,7 +3110,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "stats_ds.spread.plot.imshow()\n",
-    "plt.gca().set_title(\"Spread (%)\");\n"
+    "plt.gca().set_title(\"Spread (%)\");"
    ]
   },
   {

--- a/docs/notebooks/Validating_tides.ipynb
+++ b/docs/notebooks/Validating_tides.ipynb
@@ -158,8 +158,9 @@
     }
    ],
    "source": [
-    "from eo_tides.model import model_tides\n",
     "import pandas as pd\n",
+    "\n",
+    "from eo_tides.model import model_tides\n",
     "\n",
     "x, y = 122.2186, -18.0008\n",
     "start_time = \"2018-01-01\"\n",

--- a/eo_tides/eo.py
+++ b/eo_tides/eo.py
@@ -58,7 +58,7 @@ def _standardise_inputs(
     """
 
     # If `data` is an xarray object, extract its GeoBox and time
-    if isinstance(data, (xr.DataArray, xr.Dataset)):
+    if isinstance(data, xr.DataArray | xr.Dataset):
         # Try to extract GeoBox
         try:
             gbox: GeoBox = data.odc.geobox
@@ -544,14 +544,13 @@ def pixel_tides(
     # Reproject into original high resolution grid
     if resample:
         print("Reprojecting tides into original resolution")
-        tides_highres = _pixel_tides_resample(
+        return _pixel_tides_resample(
             tides_lowres,
             gbox,
             resample_method,
             dask_chunks,
             dask_compute,
         )
-        return tides_highres
 
     print("Returning low resolution tide array")
     return tides_lowres

--- a/eo_tides/model.py
+++ b/eo_tides/model.py
@@ -55,10 +55,7 @@ def _parallel_splits(
         raw_value = os.environ.get("CPU_GUARANTEE") or psutil.cpu_count(logical=False) or os.cpu_count() or 1
 
         # Convert to integer
-        if isinstance(raw_value, str):
-            parallel_max = int(float(raw_value))
-        else:
-            parallel_max = int(raw_value)
+        parallel_max = int(float(raw_value)) if isinstance(raw_value, str) else int(raw_value)
 
     # Calculate optimal number of splits based on constraints
     splits_by_size = total_points / min_points_per_split
@@ -66,8 +63,7 @@ def _parallel_splits(
     optimal_splits = min(splits_by_size, splits_by_cpu)
 
     # Convert to integer and ensure at least 1 split
-    final_split_count = int(max(1, optimal_splits))
-    return final_split_count
+    return int(max(1, optimal_splits))
 
 
 def _model_tides(
@@ -170,12 +166,7 @@ def _model_tides(
     hc = amp * np.exp(cph)
 
     # Compute delta times based on model
-    if pytmd_model.corrections in ("OTIS", "ATLAS", "TMD3", "netcdf"):
-        # Use delta time at 2000.0 to match TMD outputs
-        deltat = np.zeros_like(ts.tt_ut1)
-    else:
-        # Use interpolated delta times
-        deltat = ts.tt_ut1
+    deltat = np.zeros_like(ts.tt_ut1) if pytmd_model.corrections in ("OTIS", "ATLAS", "TMD3", "netcdf") else ts.tt_ut1
 
     # In "one-to-many" mode, extracted tidal constituents and timesteps
     # are repeated/multiplied out to match the number of input points and

--- a/eo_tides/stats.py
+++ b/eo_tides/stats.py
@@ -44,7 +44,7 @@ def _tide_statistics(obs_tides, all_tides, min_max_q=(0.0, 1.0), dim="time"):
     offset_high = offset_high_m / tr
 
     # Combine into a single dataset
-    stats_ds = xr.merge(
+    return xr.merge(
         [
             mot.rename("mot"),
             mat.rename("mat"),
@@ -60,8 +60,6 @@ def _tide_statistics(obs_tides, all_tides, min_max_q=(0.0, 1.0), dim="time"):
         ],
         compat="override",
     )
-
-    return stats_ds
 
 
 def _stats_plain_english(mot, mat, hot, hat, lot, lat, otr, tr, spread, offset_low, offset_high):
@@ -568,7 +566,7 @@ def pixel_stats(
     # Reproject statistics into original high resolution grid
     if resample:
         print("Reprojecting statistics into original resolution")
-        stats_highres = _pixel_tides_resample(
+        return _pixel_tides_resample(
             stats_lowres,
             gbox,
             resample_method,
@@ -576,7 +574,6 @@ def pixel_stats(
             dask_compute,
             None,
         )
-        return stats_highres
 
     print("Returning low resolution statistics array")
     return stats_lowres

--- a/eo_tides/utils.py
+++ b/eo_tides/utils.py
@@ -7,7 +7,7 @@ import pathlib
 import textwrap
 import warnings
 from collections import Counter
-from typing import List, Union
+from typing import TypeAlias
 
 import numpy as np
 import odc.geo
@@ -21,7 +21,7 @@ from scipy.spatial import cKDTree as KDTree
 from tqdm import tqdm
 
 # Type alias for all possible inputs to "time" params
-DatetimeLike = Union[np.ndarray, pd.DatetimeIndex, pd.Timestamp, datetime.datetime, str, List[str]]
+DatetimeLike: TypeAlias = np.ndarray | pd.DatetimeIndex | pd.Timestamp | datetime.datetime | str | list[str]
 
 
 def _get_duplicates(array):
@@ -54,8 +54,7 @@ def _set_directory(
     directory = pathlib.Path(directory).expanduser()
     if not directory.exists():
         raise FileNotFoundError(f"No valid tide model directory found at path `{directory}`")
-    else:
-        return directory
+    return directory
 
 
 def _standardise_time(
@@ -161,7 +160,7 @@ def _standardise_models(
             raise ValueError(error_text)
 
         # Return set of all ensemble plus any other requested models
-        models_to_process = sorted(list(set(ensemble_models + [m for m in models_requested if m != "ensemble"])))
+        models_to_process = sorted(set(ensemble_models + [m for m in models_requested if m != "ensemble"]))
 
     # Otherwise, models to process are the same as those requested
     else:
@@ -271,7 +270,7 @@ def _clip_model_file(
         for i in ["lat_z", "lat_v", "lat_u", "con"]:
             try:
                 nc_clipped[i] = nc_clipped[i].isel(nx=0)
-            except:
+            except KeyError:
                 pass
 
     return nc_clipped
@@ -558,8 +557,7 @@ def list_models(
 
         if raise_error:
             raise Exception(warning_msg)
-        else:
-            warnings.warn(warning_msg, UserWarning)
+        warnings.warn(warning_msg, UserWarning)
 
     # Return list of available and supported models
     return available_models, supported_models

--- a/eo_tides/validation.py
+++ b/eo_tides/validation.py
@@ -164,7 +164,7 @@ def _load_gesla_dataset(site, path, na_value):
     )
 
     # Combine two date fields
-    gesla_df = (
+    return (
         gesla_df.assign(
             time=pd.to_datetime(gesla_df["date"] + " " + gesla_df["time"]),
             site_code=site,
@@ -172,8 +172,6 @@ def _load_gesla_dataset(site, path, na_value):
         .drop(columns=["date"])
         .set_index("time")
     )
-
-    return gesla_df
 
 
 def _nearest_row(gdf, x, y, max_distance=None):
@@ -288,7 +286,7 @@ def load_gauge_gesla(
         site_code = [site_code] if not isinstance(site_code, list) else site_code
 
     # If x and y are tuples, use xy bounds to identify sites
-    elif isinstance(x, (tuple, list)) & isinstance(y, (tuple, list)):
+    elif isinstance(x, tuple | list) & isinstance(y, tuple | list):
         bbox = BoundingBox.from_xy(x, y)
         site_code = metadata_gdf.cx[bbox.left : bbox.right, bbox.top : bbox.bottom].index
 
@@ -317,7 +315,7 @@ def load_gauge_gesla(
     # Prepare times
     if time is None:
         time = ["1800", str(datetime.datetime.now().year)]
-    time = [time] if not isinstance(time, (list, tuple)) else time
+    time = [time] if not isinstance(time, list | tuple) else time
     start_time = _round_date_strings(time[0], round_type="start")
     end_time = _round_date_strings(time[-1], round_type="end")
 

--- a/paper/benchmarking.ipynb
+++ b/paper/benchmarking.ipynb
@@ -27,9 +27,11 @@
    "source": [
     "import os\n",
     "import platform\n",
-    "import psutil\n",
-    "import pandas as pd\n",
+    "\n",
     "import numpy as np\n",
+    "import pandas as pd\n",
+    "import psutil\n",
+    "\n",
     "from eo_tides.model import model_tides"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,17 +107,41 @@ allow_redefinition = true
 testpaths = ["tests"]
 
 [tool.ruff]
-target-version = "py310"
-line-length = 120
-fix = true
-
-[tool.ruff.format]
-preview = true
+target-version = "py310"     # Target Python 3.10 syntax
+line-length = 120            # Set max line length
+fix = true                   # Allow auto-fix when used without pre-commit
+lint.select = [
+  "I",        # Import sorting
+  "W",        # PyCodeStyle warnings
+  "F",        # Pyflakes (unused vars, imports, etc.)
+  "E",        # pycodestyle (spacing, etc.)
+  "UP",       # Modern Python idioms
+  "B006",     # Mutable default args
+  "B007",     # Reusing loop variables
+  "C4",       # Catch incorrect use of comprehensions, dict, list, etc
+  "FA",       # Enforce from __future__ import annotations
+  "ISC",      # Correct use of string concatenation
+  "ICN",      # Common import conventions
+  "RET",      # Good return practices
+  "SIM",      # Common simplification rules
+  "TID",      # Some good import practices
+  "PTH",      # Use pathlib instead of os.path
+  "NPY",      # Some numpy-specific things
+]
+lint.ignore = [
+  "E501",     # Don't enforce line length
+  "SIM105",   # contextlib.suppress
+]
+exclude = ["tests/testing.ipynb"]  # Don't modify testing notebook
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [
-    "S101"   # Assert
+  "S101",     # Allow `assert` in test files
+  "NPY002"    # Allow legacy numpy random generation
 ]
+
+[tool.ruff.format]
+preview = true    # Enable experimental formatting improvements
 
 [tool.deptry.per_rule_ignores]
 DEP002 = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,7 +127,7 @@ def satellite_ds_load(request):
         )
 
         # Search the STAC catalog for all items matching the query
-        ds = odc.stac.load(
+        return odc.stac.load(
             list(query.items()),
             bands=["nbart_red"],
             crs=crs,
@@ -137,8 +137,6 @@ def satellite_ds_load(request):
             fail_on_error=False,
             chunks={},
         )
-
-        return ds
 
 
 @pytest.fixture
@@ -250,7 +248,7 @@ def create_synthetic_eot20(base_dir="tests/data/tide_models_synthetic"):
                 "real": (("lat", "lon"), data),
             },
             coords={"lat": lat, "lon": lon},
-            attrs={"title": f"DGFI-TUM global empirical ocean tide model"},
+            attrs={"title": "DGFI-TUM global empirical ocean tide model"},
         )
 
         # Export

--- a/tests/test_eo.py
+++ b/tests/test_eo.py
@@ -358,7 +358,7 @@ def test_pixel_tides_ensemble(satellite_ds):
         ensemble_models=ENSEMBLE_MODELS,
     )
 
-    assert set(modelled_tides_ds.tide_model.values) == set([
+    assert set(modelled_tides_ds.tide_model.values) == set(
         "EOT20",
         "HAMTIDE11",
         "ensemble-best",
@@ -366,4 +366,4 @@ def test_pixel_tides_ensemble(satellite_ds):
         "ensemble-mean-top2",
         "ensemble-mean-weighted",
         "ensemble-mean",
-    ])
+    )

--- a/tests/test_eo.py
+++ b/tests/test_eo.py
@@ -358,7 +358,7 @@ def test_pixel_tides_ensemble(satellite_ds):
         ensemble_models=ENSEMBLE_MODELS,
     )
 
-    assert set(modelled_tides_ds.tide_model.values) == set(
+    assert set(modelled_tides_ds.tide_model.values) == {
         "EOT20",
         "HAMTIDE11",
         "ensemble-best",
@@ -366,4 +366,4 @@ def test_pixel_tides_ensemble(satellite_ds):
         "ensemble-mean-top2",
         "ensemble-mean-weighted",
         "ensemble-mean",
-    )
+    }

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -369,8 +369,8 @@ def test_model_tides_ensemble():
     # least one of the other models
     assert set(modelled_tides_df.columns) == set(models)
     assert all(
-        (modelled_tides_df.EOT20 == modelled_tides_df.ensemble)
-        | (modelled_tides_df.HAMTIDE11 == modelled_tides_df.ensemble)
+        (modelled_tides_df.ensemble == modelled_tides_df.EOT20)
+        | (modelled_tides_df.ensemble == modelled_tides_df.HAMTIDE11)
     )
 
     # Check that correct model is the closest at each row
@@ -404,7 +404,7 @@ def test_model_tides_ensemble():
     )
 
     # Check that expected models exist, and that valid data is produced
-    assert set(modelled_tides_df.columns) == set([
+    assert set(modelled_tides_df.columns) == set(
         "EOT20",
         "HAMTIDE11",
         "ensemble-best",
@@ -412,7 +412,7 @@ def test_model_tides_ensemble():
         "ensemble-mean-top2",
         "ensemble-mean-weighted",
         "ensemble-mean",
-    ])
+    )
     assert all(modelled_tides_df.notnull())
 
     # Long mode, custom functions
@@ -427,7 +427,7 @@ def test_model_tides_ensemble():
     )
 
     # Check that expected models exist in "tide_model" column
-    assert set(modelled_tides_df.tide_model) == set([
+    assert set(modelled_tides_df.tide_model) == set(
         "EOT20",
         "HAMTIDE11",
         "ensemble-best",
@@ -435,7 +435,7 @@ def test_model_tides_ensemble():
         "ensemble-mean-top2",
         "ensemble-mean-weighted",
         "ensemble-mean",
-    ])
+    )
 
 
 # Test ensemble dtype is set correctly

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -404,7 +404,7 @@ def test_model_tides_ensemble():
     )
 
     # Check that expected models exist, and that valid data is produced
-    assert set(modelled_tides_df.columns) == set(
+    assert set(modelled_tides_df.columns) == {
         "EOT20",
         "HAMTIDE11",
         "ensemble-best",
@@ -412,7 +412,7 @@ def test_model_tides_ensemble():
         "ensemble-mean-top2",
         "ensemble-mean-weighted",
         "ensemble-mean",
-    )
+    }
     assert all(modelled_tides_df.notnull())
 
     # Long mode, custom functions
@@ -427,7 +427,7 @@ def test_model_tides_ensemble():
     )
 
     # Check that expected models exist in "tide_model" column
-    assert set(modelled_tides_df.tide_model) == set(
+    assert set(modelled_tides_df.tide_model) == {
         "EOT20",
         "HAMTIDE11",
         "ensemble-best",
@@ -435,7 +435,7 @@ def test_model_tides_ensemble():
         "ensemble-mean-top2",
         "ensemble-mean-weighted",
         "ensemble-mean",
-    )
+    }
 
 
 # Test ensemble dtype is set correctly

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -66,7 +66,7 @@ def test_clip_models():
 
     # Assert that files were exported for all available models
     output_files = {i.stem for i in out_dir.iterdir()}
-    assert output_files == set("GOT5", "EOT20", "hamtide")
+    assert output_files == {"GOT5", "EOT20", "hamtide"}
 
     # Set modelling location
     x, y = 122.28, -18.06

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,7 @@
 import pathlib
-import tempfile
 from datetime import datetime
 
 import numpy as np
-import odc.geo.geom
 import pandas as pd
 import pytest
 
@@ -67,8 +65,8 @@ def test_clip_models():
     )
 
     # Assert that files were exported for all available models
-    output_files = set([i.stem for i in out_dir.iterdir()])
-    assert output_files == set(["GOT5", "EOT20", "hamtide"])
+    output_files = {i.stem for i in out_dir.iterdir()}
+    assert output_files == set("GOT5", "EOT20", "hamtide")
 
     # Set modelling location
     x, y = 122.28, -18.06


### PR DESCRIPTION
Moved `ruff` linting logic entirely into `pyproject.toml`, and added and ran selection of useful additional linting rules.

Also uploaded published version of `eo-tides` JOSS paper, and de-activated automated paper regeneration: https://joss.theoj.org/papers/10.21105/joss.07786